### PR TITLE
chore: move @playwright/test to devDependencies (#441)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
     "@modelcontextprotocol/sdk": "^1",
-    "@playwright/test": "^1.58.2",
     "@types/node-cron": "^3.0.11",
     "bullmq": "^5.73.0",
     "cron-parser": "^5.5.0",
@@ -22,6 +21,7 @@
     "postgres": "^3.4.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/bun": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- Moves `@playwright/test` from `dependencies` to `devDependencies`
- Playwright is test-only and should not be installed in production

## Test plan
- [ ] `bun install` still works
- [ ] E2E tests still run: `bunx playwright test`

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)