### PR TITLE
feat: CI pipeline — typecheck, tests, build, e2e (#443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,6 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bunx playwright install --with-deps chromium
-      - name: Start server
-        run: |
-          KONOHA_PORT=3202 KONOHA_TOKEN=konoha-dev-token bun run start &
-          sleep 5
-        env:
-          KONOHA_TOKEN: konoha-dev-token
-          ANTHROPIC_API_KEY: ci-placeholder
       - name: Run E2E tests
         run: bunx playwright test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,16 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [frontend-build]
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -57,7 +67,7 @@ jobs:
       - run: bunx playwright install --with-deps chromium
       - name: Start server
         run: |
-          KONOHA_TOKEN=konoha-dev-token bun run start &
+          KONOHA_PORT=3202 KONOHA_TOKEN=konoha-dev-token bun run start &
           sleep 5
         env:
           KONOHA_TOKEN: konoha-dev-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
           sleep 5
         env:
           KONOHA_TOKEN: konoha-dev-token
+          ANTHROPIC_API_KEY: ci-placeholder
       - name: Run E2E tests
         run: bunx playwright test
         env:
           KONOHA_TOKEN: konoha-dev-token
+          ANTHROPIC_API_KEY: ci-placeholder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run typecheck
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+        working-directory: frontend
+      - run: bun run test
+        working-directory: frontend
+
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+        working-directory: frontend
+      - run: bun run build
+        working-directory: frontend
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [frontend-build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bunx playwright install --with-deps chromium
+      - name: Start server
+        run: |
+          KONOHA_TOKEN=konoha-dev-token bun run start &
+          sleep 5
+        env:
+          KONOHA_TOKEN: konoha-dev-token
+      - name: Run E2E tests
+        run: bunx playwright test
+        env:
+          KONOHA_TOKEN: konoha-dev-token

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Konoha Bus
 
+[![CI](https://github.com/eaprelsky/konoha/actions/workflows/ci.yml/badge.svg)](https://github.com/eaprelsky/konoha/actions/workflows/ci.yml)
+
 Multi-agent communication bus for autonomous Claude Code agents. Redis-backed message routing with file attachments, presence tracking, and real-time streaming.
 
 ## Features

--- a/modules/workflow-engine/src/routes/cases.ts
+++ b/modules/workflow-engine/src/routes/cases.ts
@@ -59,7 +59,7 @@ casesRouter.get("/:id", async (c) => {
 
 casesRouter.post("/:id/close", requireAuth, async (c) => {
   const id = c.req.param("id");
-  const kase = await forceCloseCase(id);
+  const kase = await forceCloseCase(id!);
   if (!kase) return c.json({ error: "Case not found" }, 404);
   return c.json(kase);
 });

--- a/src/adapters/telegram-bot.ts
+++ b/src/adapters/telegram-bot.ts
@@ -81,7 +81,7 @@ function matchesFilter(update: TgUpdate, filter: Record<string, unknown>): boole
   }
 
   if (filter.content_pattern !== undefined) {
-    const text = msg.text ?? msg.caption ?? "";
+    const text = String(msg.text ?? msg.caption ?? "");
     try {
       if (!new RegExp(String(filter.content_pattern), "i").test(text)) return false;
     } catch {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "types": ["bun-types"]
   },
   "include": ["src/**/*.ts", "core/**/*.ts", "modules/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "modules/workflow-engine/frontend/**"]
 }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with 4 jobs triggered on push/PR to main
- Uses `oven-sh/setup-bun@v2` (official Bun GitHub Action)

## Jobs
| Job | What it runs |
|-----|-------------|
| `typecheck` | `bun run typecheck` → `bunx tsc --noEmit` |
| `frontend-test` | `bun run test` in `frontend/` → Vitest unit tests |
| `frontend-build` | `bun run build` in `frontend/` → Vite build |
| `e2e` | Playwright against live server (`KONOHA_TOKEN=konoha-dev-token`) |

## Test plan
- [ ] CI runs on this PR
- [ ] All 4 jobs pass

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)