### PR TITLE
fix: suppress Akamaru permission_prompt false positive on idle state

### DIFF
--- a/scripts/akamaru.py
+++ b/scripts/akamaru.py
@@ -482,7 +482,7 @@ def check_tmux_sessions(paused: set[str] = frozenset()) -> list[str]:
                     # Detect permission prompt freeze (#69)
                     # Filter out status-bar lines (e.g. "bypass permissions on (shift+tab to cycle)")
                     # and MemPalace write-progress lines (e.g. "Doodling…").
-                    STATUS_BAR_NOISE = ["bypass permissions", "shift+tab", "bypassPermissions", "Doodling"]
+                    STATUS_BAR_NOISE = ["bypass permissions", "shift+tab", "bypassPermissions", "Doodling", "? for shortcuts"]
                     prompt_lines = [l for l in lines[-15:] if not any(n in l for n in STATUS_BAR_NOISE)]
                     pane_text = "\n".join(prompt_lines)
                     PERMISSION_PATTERNS = [
@@ -529,7 +529,10 @@ def check_tmux_sessions(paused: set[str] = frozenset()) -> list[str]:
                         any(p in pane_text for p in PERMISSION_PATTERNS) and
                         any(m in pane_text for m in PERMISSION_UI_MARKERS)
                     )
-                    if not is_actively_working and is_permission_prompt:
+                    # Skip when agent is at idle prompt (❯ or ? for shortcuts) —
+                    # no permission UI is rendered at idle. Prevents false positives
+                    # when scrollback contains prompt-like text from earlier output (#537).
+                    if not is_actively_working and is_permission_prompt and not is_idle:
                         key = f"tmux:{session}:permission_prompt"
                         if should_alert(key):
                             alerts.append(


### PR DESCRIPTION
## Summary
Fixes false positive `frozen=permission_prompt` alerts from Akamaru when an agent is at the normal Claude Code idle state showing `? for shortcuts`.

Closes #537
Closes #538 (duplicate)

## Root Cause
Two issues in the permission prompt detector:
1. `? for shortcuts` (Claude Code idle hint) was not filtered from `STATUS_BAR_NOISE`, so it appeared in the prompt-line analysis text
2. The detector did not check the already-computed `is_idle` flag — if scrollback contained prompt-like text from earlier output, and the agent happened to be idle, the alert fired

## Changes
| Change | File | Why |
|--------|------|-----|
| Add `"? for shortcuts"` to `STATUS_BAR_NOISE` | `scripts/akamaru.py:485` | Filters idle hint from prompt analysis |
| Add `and not is_idle` to alert condition | `scripts/akamaru.py:535` | If agent is at idle prompt, no permission UI is rendered — skip alert entirely |

Both deployed and git repo versions synced.

## Test plan
- [ ] Verify Akamaru restarts cleanly with new code
- [ ] Monitor Kiba logs: `? for shortcuts` idle state should NOT produce frozen=permission_prompt alerts
- [ ] Real permission prompts (Allow? Y/n) should still trigger alerts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)